### PR TITLE
fix(acmesmith_client): remove #fetch

### DIFF
--- a/lib/acmesmith/client.rb
+++ b/lib/acmesmith/client.rb
@@ -13,7 +13,7 @@ module Acmesmith
 
     def initialize(config: nil)
       @config ||= config
-      @authorize_retry = config.fetch('authorize_retry', DEFAULT_AUTHORIZE_RETRY)
+      @authorize_retry = config['authorize_retry'] || DEFAULT_AUTHORIZE_RETRY
     end
 
     def register(contact)


### PR DESCRIPTION
https://jira.railsc.ru/browse/DEVOPS-812

Нельзя вызвать `#fetch`, т.к. `config` не хэш, а инстанс `Acmesmith::Config`.