### PR TITLE
refact: acme_client

### DIFF
--- a/lib/acmesmith/acme_client.rb
+++ b/lib/acmesmith/acme_client.rb
@@ -43,6 +43,17 @@ module Acmesmith
       end
     end
 
+    def jwk_thumbprint
+      @acme.jwk.thumbprint
+    end
+
+    # @param [Acmesmith::Certificate] certificate
+    def revoke_certificate(certificate)
+      retry_once_on_bad_nonce do
+        @acme.revoke_certificate(certificate)
+      end
+    end
+
     private
 
     def retry_once_on_bad_nonce(&block)


### PR DESCRIPTION
https://jira.railsc.ru/browse/DEVOPS-812

Разрабы сделали "типаобертку" над `Acme::Client`, чтобы добавить `retry` для некоторых методов.
https://github.com/rezerbit/acmesmith/commit/2d8818430a967237b9c070c490b5f5f9a23899bb#diff-d1f08e0f64292546ce44ad4704790bf5L235

Но сделали это по-корявому. https://github.com/rezerbit/acmesmith/commit/2d8818430a967237b9c070c490b5f5f9a23899bb#diff-7f1334d6716ac435992d218f4922f86eR4
Т.е. в обертке доступны не все методы. И нельзя получить доступ к инстансу `Acme::Client`. Можно, конечно, `instance_variable_get(:@acme)`, но это хак.

Вместо их класса сделал обычную обертку.
